### PR TITLE
Nucivic open data schema map issue 37 group list endpoint

### DIFF
--- a/modules/open_data_schema_ckan/open_data_schema_ckan.module
+++ b/modules/open_data_schema_ckan/open_data_schema_ckan.module
@@ -65,16 +65,28 @@ function open_data_schema_ckan_open_data_schema_map_results_alter(&$result, $mac
       }
       $result['result'] = $list;
     }
-    elseif ($machine_name == 'ckan_package_list') {      
+    elseif ($machine_name == 'ckan_package_list') {
       $result['help'] = t("Return a list of the names of the site's datasets (packages).\n\n :param limit: if given, the list of datasets will be broken into pages of\n at most ``limit`` datasets per page and only one page will be returned\n at a time (optional)\n :type limit: int\n :param offset: when ``limit`` is given, the offset to start returning packages from\n :type offset: int\n\n :rtype: list of strings\n\n");
       foreach ($result['result'] as $num => $data) {
         // This endpoint just produces a list.
-        foreach ($data as $api_field => $item) {          
+        foreach ($data as $api_field => $item) {
           $list[] = $data['name'];
         }
       }
 
       $result['result'] = $list;
-    }    
+    } 
+    elseif ($machine_name == 'ckan_group_list') {
+      $result['help'] = t("Return a list of the names of the site's groups.\n\n    :param order_by: the field to sort the list by, must be ``'name'`` or\n      ``'packages'`` (optional, default: ``'name'``) Deprecated use sort.\n    :type order_by: string\n    :param sort: sorting of the search results.  Optional.  Default:\n        \"name asc\" string of field name and sort-order. The allowed fields are\n        'name' and 'packages'\n    :type sort: string\n    :param all_fields: return full group dictionaries instead of  just names\n        (optional, default: ``False``)\n    :type all_fields: boolean\n\n    :rtype: list of strings");
+      foreach ($result['result'] as $num => $data) {
+        // This endpoint just produces a list.
+        foreach ($data as $api_field => $item) {
+          $list[] = $item;
+        }
+      }
+
+      $result['result'] = $list;
+    }
+     
   }
 }


### PR DESCRIPTION
NuCivic/nucivic-internal#37

This PR depends on ed8cdbfeb6a36c8e31beafa48586cea7eecdd318 NuCivic/nucivic-internal#36  
### Accepting test

Remove harcoded group list from dkan_dataset_api.module 
Clear cache
When I go to /api/3/action/group_list I should see a list of sluggified items inside the results key
