### PR TITLE
NuCivic/dkan#182 Changing result key from array to dict

### DIFF
--- a/modules/open_data_schema_ckan/open_data_schema_ckan.module
+++ b/modules/open_data_schema_ckan/open_data_schema_ckan.module
@@ -53,6 +53,7 @@ function open_data_schema_ckan_open_data_schema_map_results_alter(&$result, $mac
     }
     if ($machine_name == 'ckan_package_show') {
       $result['help'] = t('Return the metadata of a dataset (package) and its resources. :param id: the id or name of the dataset :type id: string');
+      $result['result'] = $result['result'][0];
     }
     elseif ($machine_name == 'ckan_revision_list') {
       $result['help'] = t("Return a list of the IDs of the site's revisions.\n\n :rtype: list of strings.");


### PR DESCRIPTION
NuCivic/dkan#182
### Accepting test

When you go to /api/3/action/package_show?id=<uuid> then result key must be filled with a dict instead of an array.
