### PR TITLE
Splitting render and output for open_data_schema_map

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -334,6 +334,7 @@ function open_data_schema_map_api_load_all() {
   foreach ($list as $item) {
     $records[] = open_data_schema_map_api_load($item);
   }
+
   return $records;
 }
 
@@ -973,12 +974,14 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
 /**
  * Function that renders and odsm api for endpoint.
  */
-function open_data_schema_map_render_api($api, $query = NULL) {
+function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
+  if (!isset($queries)) {
+    $queries = drupal_get_query_parameters();
+  }
   if (!isset($query)) {
     $query = $_GET;
   }
   $headers = array();
-  $queries = drupal_get_query_parameters();
   try {
     $args = open_data_schema_map_endpoint_args($api->mapping, $queries, $api->arguments);
     if (isset($args['required'])) {

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -969,3 +969,45 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
     }
   }
 }
+
+/**
+ * Function that renders and odsm api for endpoint.
+ */
+function open_data_schema_map_render_api($api, $query = NULL) {
+  if (!isset($query)) {
+    $query = $_GET;
+  }
+  $headers = array();
+  $queries = drupal_get_query_parameters();
+  try {
+    $args = open_data_schema_map_endpoint_args($api->mapping, $queries, $api->arguments);
+    if (isset($args['required'])) {
+      $error_data = array(
+        '__type' => 'Validation Error',
+        'name_or_id' => array('Missing Value'),
+      );
+      throw new OpenDataSchemaMapException(t('Required field "!field" is missing', array('!field' => $args['required'])), 400, $error_data);
+    }
+    // This endpoint is created in code.
+    if (isset($api->callback) && function_exists($api->callback)) {
+      $function = $api->callback;
+      $result = $function($queries, $api->arguments);
+    }
+    // This endpoint was created with the UI.
+    else {
+      $offset = open_data_schema_map_endpoint_special_arg($args, 'offset');
+      $limit = open_data_schema_map_endpoint_special_arg($args, 'limit');
+      $ids = open_data_schema_map_endpoint_query($api, $limit, $offset, $args);
+      $result = open_data_schema_map_endpoint_process_map($ids, $api);
+    }
+  }
+  catch (OpenDataSchemaMapException $e) {
+    $headers['Status'] = $e->getHTTPError();
+    $result['error'] = $e->getData();
+  }
+  drupal_alter('open_data_schema_map_results', $result, $api->machine_name, $api->api_schema);
+  return array(
+    'result' => $result,
+    'headers' => $headers,
+  );
+}

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -382,34 +382,12 @@ function open_data_schema_map_add_type(&$values, $mapping) {
  * Creates endpoint.
  */
 function open_data_schema_map_endpoint($api) {
-  $queries = drupal_get_query_parameters();
-  try {
-    $args = open_data_schema_map_endpoint_args($api->mapping, $queries, $api->arguments);
-    if (isset($args['required'])) {
-      $error_data = array(
-        '__type' => 'Validation Error',
-        'name_or_id' => array('Missing Value'),
-      );
-      throw new OpenDataSchemaMapException(t('Required field "!field" is missing', array('!field' => $args['required'])), 400, $error_data);
-    }
-    // This endpoint is created in code.
-    if (isset($api->callback) && function_exists($api->callback)) {
-      $function = $api->callback;
-      $result = $function($queries, $api->arguments);
-    }
-    // This endpoint was created with the UI.
-    else {
-      $offset = open_data_schema_map_endpoint_special_arg($args, 'offset');
-      $limit = open_data_schema_map_endpoint_special_arg($args, 'limit');
-      $ids = open_data_schema_map_endpoint_query($api, $limit, $offset, $args);
-      $result = open_data_schema_map_endpoint_process_map($ids, $api);
-    }
-  }
-  catch (OpenDataSchemaMapException $e) {
-    drupal_add_http_header('Status', $e->getHTTPError());
-    $result['error'] = $e->getData();
-  }
-  drupal_alter('open_data_schema_map_results', $result, $api->machine_name, $api->api_schema);
+  $render = open_data_schema_map_render_api($api);
+  $headers = $render['headers'];
+  $result = $render['result'];
 
+  foreach ($headers as $key => $value) {
+    drupal_add_http_header($key, $value);
+  }
   return drupal_json_output($result);
 }


### PR DESCRIPTION
What the title says.

### Acceptance Test

- [x] Existence api endpoints should work as before.
