### PR TITLE
XML Output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+vendor
+vendor/*
+composer.lock

--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ When you return to the tags section of the form after saving, you will now see a
 
 You are not limited by the schemas included with this module; any Open Data schema may be defined in a custom module. Use the open_data_schema_ckan module as a model to get started.
 
+### Using the xml output module
+
+We've isolated xml output into it's own module. A few reasons why:
+
++ It relies on a composer dependency
++ This module is distributed with dkan, a drupal installation profile, and we don't have a way of installing composer dependencies while building the distro with ```drush make```
++ We don't want to force all this trouble on users that just want ***json output*** 
+
+Because of all this, if you still want to use xml output for your odsm endpoints (we don't judge), you need to:
+
+
++ Install composer dependencies:
+
+```
+$ cd modules/open_data_schema_map_xml_output
+$ composer install
+```
+
++ Enable module
+
+```
+$ drush -y en open_data_schema_map_xml_output
+```
+
+If you need instructions to install composer globally in your system please refer to https://getcomposer.org/doc/00-intro.md#globally.
+
 ### Date format
 Date formats can be chanaged manually by changing the "Medium" date time format in "admin/config/regional/date-time" or in code by using one of the alter hooks:
 ![screen shot 2014-09-04 at 11 15 01 am](https://cloud.githubusercontent.com/assets/512243/4152408/a9cb06b2-344e-11e4-84c8-c2174b5fc566.png)

--- a/modules/open_data_schema_ckan/open_data_schema_ckan.module
+++ b/modules/open_data_schema_ckan/open_data_schema_ckan.module
@@ -27,6 +27,7 @@ function open_data_schema_ckan_open_data_schema_map_load($machine_name) {
     $record->bundle = '';
     $record->arguments = array();
     $record->machine_name = 'ckan_site_read';
+    $record->outputformat = 'json';
     $record->endpoint = 'api/3/action/site_read';
     $record->callback = 'open_data_schema_ckan_site_read_callback';
     return $record;
@@ -40,6 +41,7 @@ function open_data_schema_ckan_open_data_schema_map_load($machine_name) {
     $record->bundle = '';
     $record->arguments = array();
     $record->machine_name = 'ckan_revision_list';
+    $record->outputformat = 'json';
     $record->endpoint = 'api/3/action/revision_list';
     $record->callback = 'open_data_schema_ckan_revision_list_callback';
     return $record;
@@ -53,6 +55,7 @@ function open_data_schema_ckan_open_data_schema_map_load($machine_name) {
     $record->bundle = '';
     $record->arguments = array('1' => array('field' => 'id', 'required' => 1));
     $record->machine_name = 'ckan_package_revision_list';
+    $record->outputformat = 'json';
     $record->endpoint = 'api/3/action/package_revision_list';
     $record->callback = 'open_data_schema_ckan_package_revision_list_callback';
     return $record;

--- a/modules/open_data_schema_map_xml_output/.gitignore
+++ b/modules/open_data_schema_map_xml_output/.gitignore
@@ -1,0 +1,3 @@
+vendor
+vendor/*
+composer.lock

--- a/modules/open_data_schema_map_xml_output/composer.json
+++ b/modules/open_data_schema_map_xml_output/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "symfony/serializer": "*"
+    }
+}

--- a/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.info
+++ b/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.info
@@ -1,0 +1,6 @@
+name = Project Open Data Schema XML Output
+description = Provides xml output for for Open Data Schema Map.
+core = 7.x
+package = Open Data
+version = 7.x-1.x
+dependencies[] = open_data_schema_map

--- a/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.install
+++ b/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Schemas odsm xml output.
+ */
+
+
+function open_data_schema_map_xml_output_update_7001() {
+
+  $column = array(
+    'type' => 'varchar',
+    'description' => "XML Root",
+    'length' => 60,
+    'not null' => False,
+    'default' => 'records',
+  );
+
+  $data_table_name = 'open_data_schema_map';
+  if (!db_field_exists('open_data_schema_map', 'xml_root')) {
+    db_add_field($data_table_name, 'xml_root', $column);
+  }
+
+  $column = array(
+    'type' => 'varchar',
+    'description' => "XML Default Tag",
+    'length' => 60,
+    'not null' => False,
+    'default' => 'record',
+  );
+
+  $data_table_name = 'open_data_schema_map';
+  if (!db_field_exists('open_data_schema_map', 'xml_defaulttag')) {
+    db_add_field($data_table_name, 'xml_defaulttag', $column);
+  }
+}
+

--- a/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.module
+++ b/modules/open_data_schema_map_xml_output/open_data_schema_map_xml_output.module
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * @file
+ * Provides XML output for Open Data Schema Map.
+ */
+include __DIR__ . '/vendor/autoload.php';
+
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+
+define("DEFAULT_XML_ROOT", "records");
+define("DEFAULT_XML_TAG", "record");
+
+/**
+ * Implements hook_odsm_form_alter().
+ */
+function open_data_schema_map_xml_output_odsm_form_alter(&$form, $api) {
+  $form['xml_root'] = array(
+    '#title' => 'XML Root',
+    '#type' => 'textfield',
+    '#description' => t('(XML only) Enter the XML Root Name (default: records).'),
+    '#required' => False,
+    '#weight' => 3,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="outputformat"]' => array('value' => 'xml'),
+      ),
+    ),
+  );
+  $form['xml_defaulttag'] = array(
+    '#title' => 'XML Default Node',
+    '#type' => 'textfield',
+    '#description' => t('(XML only) Enter the XML Default Node Name (default: record).'),
+    '#required' => False,
+    '#weight' => 4,
+    '#states' => array(
+      'visible' => array(
+        ':input[name="outputformat"]' => array('value' => 'xml'),
+      ),
+    ),
+  );
+}
+
+/**
+ * Implements hook_odsm_page_overview_alter().
+ */
+function open_data_schema_map_xml_output_odsm_page_overview_alter(&$data) {
+  unset($data['xml_root']);
+  unset($data['xml_defaulttag']);
+}
+
+/**
+ * Implements hook_odsm_output_format().
+ */
+function open_data_schema_map_xml_output_odsm_output_format() {
+  return array(
+    'xml' => 'open_data_schema_map_xml_output_render'
+  );
+}
+
+/**
+ * Render function for hook_odsm_output_format implementation
+ */
+
+function open_data_schema_map_xml_output_render($api, $result) {
+  // We are returning XML, so tell the browser.
+  drupal_add_http_header('Content-Type', 'application/xml');
+  $xml_root = DEFAULT_XML_ROOT;
+  $xml_defaulttag = DEFAULT_XML_TAG;
+  if (isset($api->xml_root) && $api->xml_root != '') {
+    $xml_root = $api->xml_root;
+  }
+  if (isset($api->xml_defaulttag) && $api->xml_defaulttag != '') {
+    $xml_defaulttag = $api->xml_defaulttag;
+  }
+
+  $xml = array();
+  $xml[$xml_defaulttag] = $result;
+  unset($xml[$xml_defaulttag]['key']);
+
+  // Serialize
+  $encoders = array(
+    new XmlEncoder($xml_root)
+  );
+  $normalizers = array(new GetSetMethodNormalizer());
+  $serializer = new Serializer($normalizers, $encoders);
+
+  echo $serializer->serialize($xml, 'xml');
+}
+

--- a/open_data_schema_map.install
+++ b/open_data_schema_map.install
@@ -67,6 +67,13 @@ function open_data_schema_map_schema() {
         'size' => 'big',
         'serialize' => TRUE,
       ),
+      'outputformat' => array(
+        'description' => 'Output Format.',
+        'type' => 'varchar',
+        'length' => 20,
+        'not null' => True,
+        'default' => 'json',
+      ),
       'endpoint' => array(
         'type' => 'varchar',
         'length' => 256,
@@ -84,4 +91,28 @@ function open_data_schema_map_schema() {
     'primary key' => array('id'),
   );
   return $schema;
+}
+
+
+/**
+ *
+ * Ensures that the output format field is in the table
+ * Also sets outputformat to 'json' for all existing entries
+ *
+ */
+
+function open_data_schema_map_update_7001() {
+
+  $column = array(
+    'type' => 'varchar',
+    'description' => "Output Format",
+    'length' => 20,
+    'not null' => True,
+    'default' => 'json',
+  );
+
+  $data_table_name = 'open_data_schema_map';
+  if (!db_field_exists('open_data_schema_map', 'outputformat')) {
+    db_add_field($data_table_name, 'outputformat', $column);
+  }
 }

--- a/open_data_schema_map.output.inc
+++ b/open_data_schema_map.output.inc
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @file
+ * Output formats for ODSM.
+ */
+
+/**
+ * Prettify output formats array for odsm form
+ */
+
+function open_data_schema_map_form_output_formats() {
+  $output_formats = array_keys(open_data_schema_map_retrieve_output_formats());
+  $r = array();
+  foreach ($output_formats as $output_format) {
+    $r[$output_format] = $output_format;
+  }
+  return $r;
+}
+
+/**
+ * Returns list of formats off hook_odsm_output_format implementations.
+ */
+function open_data_schema_map_retrieve_output_formats() {
+  $output_formats = array();
+  foreach (module_implements('odsm_output_format') as $module) {
+    $module_outputs = $module . '_odsm_output_format';
+    $module_outputs = $module_outputs();
+    foreach ($module_outputs as $key => $value) {
+      if (!in_array($key, array_keys($output_formats))) {
+        $output_formats[$key] = $value;
+      }
+    }
+  }
+  return $output_formats;
+}
+
+/**
+ * Implements hook_odsm_output_format().
+ */
+function open_data_schema_map_odsm_output_format() {
+  return array(
+    'json' => 'open_data_schema_map_json_output',
+    'json-pretty' => 'open_data_schema_map_json_pretty_output',
+  );
+}
+
+/**
+ * Default json output.
+ */
+function open_data_schema_map_json_output($api, $results) {
+  return drupal_json_output($results);
+}
+
+/**
+ * Alternative "pretty" json output if php -v > 5.3.
+ */
+function open_data_schema_map_json_pretty_output($api, $results) {
+  // We are returning JSON, so tell the browser.
+  drupal_add_http_header('Content-Type', 'application/json');
+
+  if (isset($results)) {
+    // The PHP version cannot change within a request.
+    static $php530;
+    if (!isset($php530)) {
+      $php530 = version_compare(PHP_VERSION, '5.3.0', '>=');
+    }
+    if ($php530) {
+      echo json_encode($results, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+    // json_encode() escapes <, >, ', &, and " using its options parameter, but
+    // does not support this parameter prior to PHP 5.3.0.
+    include_once DRUPAL_ROOT . '/includes/json-encode.inc';
+    echo drupal_json_encode_helper($results);
+  }
+}

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -5,6 +5,9 @@
  * Pages and forms for ODSM.
  */
 
+$module_path = drupal_get_path('module', 'open_data_schema_map');
+require_once $module_path . '/open_data_schema_map.output.inc';
+
 /**
  * Callback for ODSM overiew page.
  */
@@ -20,6 +23,11 @@ function open_data_schema_map_page_overview() {
     $data['delete'] = isset($data['callback']) ? '' : l(t('delete'), 'admin/config/services/odsm/delete/' . $data['machine_name']);
     unset($data['machine_name']);
     unset($data['callback']);
+
+    foreach (module_implements('odsm_page_overview_alter') as $module) {
+      $function = $module . '_odsm_page_overview_alter';
+      $function($data);
+    }
     // TODO: report features status.
     // $data['configuration'] = theme('entity_status',
     // array('status' => $data['features']));
@@ -33,6 +41,7 @@ function open_data_schema_map_page_overview() {
   $header[] = t('Entity');
   $header[] = t('Bundle');
   $header[] = t('Endpoint');
+  $header[] = t('Output Format');
   $header[] = t('Edit');
   $header[] = t('Delete');
   // $header[] = t('Configuration');
@@ -70,7 +79,7 @@ function open_data_schema_map_delete_submit(array $form, array &$form_state) {
   $api = $form['#api'];
   $id = $api->id;
   db_delete('open_data_schema_map')
-  ->condition('id', $id)
+    ->condition('id', $id)
     ->execute();
 
   // Rebuild menu so the API is not available anymore.
@@ -108,17 +117,26 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
   if ($list) {
     $markup = t('Choose from the available APIs:') . theme('item_list', $list);
   }
+
   $entity_types = entity_get_info();
   foreach ($entity_types as $entity_name => $entity_info) {
     $entity_list[$entity_name] = $entity_info['label'];
   }
   $selected_entity = '';
   $selected_schema = '';
+  $selected_outputformat = '';
   if (isset($form_state['triggering_element']['#name']) && $name = $form_state['triggering_element']['#name']) {
     $selected_entity = $form_state['triggering_element']['#value'];
   }
   elseif ($api) {
     $selected_entity = $api->type;
+  }
+  $output_formats = open_data_schema_map_form_output_formats();
+  if (isset($form_state['triggering_element']['#outputformat']) && $outputformat = $form_state['triggering_element']['#outputformat']) {
+    $selected_outputformat = $form_state['triggering_element']['#value'];
+  }
+  else {
+    $selected_outputformat = $output_formats['json'];
   }
   $form['name'] = array(
     '#title' => 'Title',
@@ -187,6 +205,15 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     '#required' => TRUE,
     '#weight' => 1,
   );
+  $form['outputformat'] = array(
+    '#title' => 'Output Format',
+    '#type' => 'select',
+    '#description' => t('Select from the available output formats.'),
+    '#options' => $output_formats,
+    '#required' => TRUE,
+    '#weight' => 2,
+  );
+
   $form['enabled'] = array(
     '#title' => 'Enabled',
     '#type' => 'checkbox',
@@ -199,7 +226,7 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     '#description' => t('Select from the available schemas.'),
     '#options' => $list,
     '#required' => TRUE,
-    '#weight' => 2,
+    '#weight' => 5,
   );
   // Only add Schema if we've already saved the initial config.
   if ($api) {
@@ -272,6 +299,7 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     $form['type']['#default_value'] = $api->type;
     $form['bundle']['#default_value'] = $api->bundle;
     $form['endpoint']['#default_value'] = $api->endpoint;
+    $form['outputformat']['#default_value'] = $api->outputformat;
     $form['enabled']['#default_value'] = $api->enabled;
     $form['api_schema']['#default_value'] = $api->api_schema;
     $form['arguments']['#default_value'] = $api->arguments;
@@ -297,6 +325,11 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     );
   }
   $form['#tree'] = TRUE;
+
+  foreach (module_implements('odsm_form_alter') as $module) {
+    $function = $module . '_odsm_form_alter';
+    $function($form, $api);
+  }
   return $form;
 }
 
@@ -395,5 +428,13 @@ function open_data_schema_map_endpoint($api) {
   foreach ($headers as $key => $value) {
     drupal_add_http_header($key, $value);
   }
-  return drupal_json_output($result);
+
+  $output_formats = open_data_schema_map_retrieve_output_formats();
+  if (in_array($api->outputformat, array_keys($output_formats))) {
+    $function = $output_formats[$api->outputformat];
+    return $function($api, $result);
+  }
+  else {
+    drupal_set_message("Invalid output format", "error");
+  }
 }


### PR DESCRIPTION
NuCivic/dkan#320: + Isolating xml format output in it's own module + defined odsm_output_format hook for third party modules to subscribe custom formatters for osdm output

### Acceptance Test

- [x] Wait for tests to pass
- [x] Build dkan QA Site ->  http://dkan_320.dkan.qa.nuamsdev.com/

### Post Merge Tasks
- [ ] Close and delete NuCivic/dkan_dataset#100
- [ ] Close and delete NuCivic/dkan#417