### PR TITLE
Allow clients to override the default email.

### DIFF
--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -251,7 +251,7 @@ function odsm_add_data_JSON_defaults(&$dataset) {
     $dataset['keyword'] = array(t("No keyword provided"));
   }
   if ((isset($dataset['contactPoint']['hasEmail']) && !$dataset['contactPoint']['hasEmail']) || !isset($dataset['contactPoint']['hasEmail'])) {
-    $dataset['contactPoint']['hasEmail'] = 'mailto:noemailprovided@usa.gov';
+    $dataset['contactPoint']['hasEmail'] = 'mailto:' . variable_get('pod_default_email', 'noemailprovided@usa.gov');
   }
   if ((isset($dataset['contactPoint']['fn']) && !$dataset['contactPoint']['fn']) || !isset($dataset['contactPoint']['fn'])) {
     $dataset['contactPoint']['fn'] = t('unknown');


### PR DESCRIPTION
Allow clients to override the default email when no emails are provided.

Ref. https://github.com/NuCivic/External-HHS/issues/165#issuecomment-136819224
     https://github.com/NuCivic/healthdata/pull/407