### PR TITLE
Better strategy to handle lookup in alias table for package_show

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -949,7 +949,12 @@ function open_data_schema_map_endpoint_special_arg(&$args, $type) {
  */
 function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
   if ($arg['token']['value'] == '[node:url:arg:last]' || $arg['token']['value'] == '[node:url:args:last]') {
-    $result = db_select('url_alias', 'url')->fields('url', array('source', 'alias'))->execute()->fetchAll();
+    // Query against a like statement to reduce forloop 
+    $result = db_select('url_alias', 'url')
+              ->fields('url', array('source', 'alias'))
+              ->condition('alias', '%/' . $arg['query'], 'LIKE')
+              ->execute()
+              ->fetchAll(); 
     $field[1] = 'nid';
     foreach ($result as $result) {
       $alias = explode('/', $result->alias);
@@ -959,6 +964,14 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
         return;
       }
     }
+    throw new OpenDataSchemaMapException(
+      t('"!query" does not return results', array('!query' => $arg['query'])),
+      404,
+      array(
+        '__type' => 'Query Error',
+        'name_or_id' => t('Query \'!query\' doesn\'t return results', array('!query' => $arg['query'])),
+      )
+    );
   }
   elseif ($arg['token']['value'] == '[node:url]') {
     $field[1] = 'nid';


### PR DESCRIPTION
Issue #CIVIC-2352: Better strategy to handle lookup in alias table

Originally loaded entire alias table into a forloop to look for a match - now filters on the initial mysql query with a LIKE so that the forloop should only recieve one or two results to parse. On sites with thousands of datasets this was causing performance problems.

Also add proper error handling for no results