### PR TITLE
Recreates PR for package_show performance fix

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -949,7 +949,12 @@ function open_data_schema_map_endpoint_special_arg(&$args, $type) {
  */
 function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
   if ($arg['token']['value'] == '[node:url:arg:last]' || $arg['token']['value'] == '[node:url:args:last]') {
-    $result = db_select('url_alias', 'url')->fields('url', array('source', 'alias'))->execute()->fetchAll();
+    // Query against a like statement to reduce forloop 
+    $result = db_select('url_alias', 'url')
+              ->fields('url', array('source', 'alias'))
+              ->condition('alias', '%/' . $arg['query'], 'LIKE')
+              ->execute()
+              ->fetchAll(); 
     $field[1] = 'nid';
     foreach ($result as $result) {
       $alias = explode('/', $result->alias);
@@ -959,6 +964,14 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
         return;
       }
     }
+    throw new OpenDataSchemaMapException(
+      t('"!query" does not return results', array('!query' => $arg['query'])),
+      404,
+      array(
+        '__type' => 'Query Error',
+        'name_or_id' => t('Query \'!query\' doesn\'t return results', array('!query' => $arg['query'])),
+      )
+    );
   }
   elseif ($arg['token']['value'] == '[node:url]') {
     $field[1] = 'nid';
@@ -1028,12 +1041,13 @@ function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
     $temp[] = 'open_data_schema_pod';
     $modules = $temp;
   }
-
+  if (!isset($ids)) {
+    $ids = array();
+  }
   foreach ($modules as $module) {
     $function = $module . '_open_data_schema_map_results_alter';
     $function($result, $api->machine_name, $api->api_schema, $ids);
   }
-
   return array(
     'result' => $result,
     'headers' => $headers,

--- a/test/OpenDataSchemaMapBaseTest.php
+++ b/test/OpenDataSchemaMapBaseTest.php
@@ -2,14 +2,22 @@
 class OpenDataSchemaMapBaseTest  extends PHPUnit_Framework_TestCase
 {
 
-  public static function setUpBeforeClass()
-  {
+  public static function setUpBeforeClass() {
     // Change /data.json path to /json during tests.
     $data_json = open_data_schema_map_api_load('data_json_1_1');
     $data_json->endpoint = 'json';
     drupal_write_record('open_data_schema_map', $data_json, 'id');
     drupal_static_reset('open_data_schema_map_api_load_all');
     menu_rebuild();
+  }
+
+  public static function tearDownAfterClass() {
+    // Restore /data.json path
+    $data_json = open_data_schema_map_api_load('data_json_1_1');
+    $data_json->endpoint = 'data.json';
+    drupal_write_record('open_data_schema_map', $data_json, 'id');
+    drupal_static_reset('open_data_schema_map_api_load_all');
+    menu_rebuild(); 
   }
 
   /**
@@ -191,7 +199,6 @@ class OpenDataSchemaMapBaseTest  extends PHPUnit_Framework_TestCase
         $options['base_url'] = $base_url . ':' . $base_url_port;
       }
       $url = url($uri['uri'], $options);
-      var_dump($url);
       $result = drupal_http_request($url);
       $this->assertTrue($result->code == 200 ? TRUE : FALSE);
       $succesful[] = $result;

--- a/test/boot.php
+++ b/test/boot.php
@@ -13,9 +13,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $dir = implode('/', array(__DIR__, '..', '..', 'docroot'));
 
 // Host.
-$uri = getenv('DKAN_WEB_1_ENV_VIRTUAL_HOST') ? 'http://' . getenv('DKAN_WEB_1_ENV_VIRTUAL_HOST') : 'http://127.0.0.1:8888';
-
-var_dump($uri);
+$uri = getenv('DKAN_WEB_1_PORT_80_TCP') ? str_replace('tcp://', 'http://', getenv('DKAN_WEB_1_PORT_80_TCP')) : 'http://127.0.0.1:8888';
 
 $driver = new DrupalDriver($dir, $uri);
 $driver->setCoreFromVersion();


### PR DESCRIPTION
Issue #CIVIC-2352: Better strategy to handle lookup in alias table
NuCivic/dkan#1217

Originally loaded entire alias table into a forloop to look for a match - now filters on the initial mysql query with a LIKE so that the forloop should only recieve one or two results to parse. On sites with thousands of datasets this was causing performance problems.

Also add proper error handling for no results