### PR TITLE
Fix describedBy output

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1165,6 +1165,9 @@ function open_data_schema_map_tokens_alter(array &$replacements, array $context)
   if (isset($replacements['[node:field-frequency]']) && isset($context['data']['node']->field_frequency['und'])) {
     $replacements['[node:field-frequency]'] = open_data_schema_map_accrual_iso_8601_value($replacements['[node:field-frequency]']);
   }
+  if (isset($replacements['[node:field-data-dictionary]'])) {
+    $replacements['[node:field-data-dictionary]'] = check_url($context['data']['node']->field_data_dictionary[LANGUAGE_NONE][0]['value']);
+  }
 }
 
 /**


### PR DESCRIPTION
The dictionary field which maps to the open Data Schema "describedBy" field is
always a URL and if not added to a dataset as a plaintext URL the data.json
created with this field fails validation.

REF CIVIC-4269.
REF: https://jira.govdelivery.com/browse/CIVIC-4343

ORIG ISSUE: https://github.com/NuCivic/dkan/pull/1294

QA Steps
===
- [ ] create data.json with open data schema map enabled.
- [ ] verify data.json is valid
- [ ] verify that solution fixes issue even if URl is the maximum length HTTP/1.1 allowable size.