### PR TITLE
Check for property existance before assignment

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.x
+-------
+- #85 Add checks for property existance during odsm features rebuild.
+
 7.x-1.12.14
 -----------
 - Add support for validation of data.json files from sites with self-signed certificates.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-7.x-1.x
+7.x-1.13.x
 -------
 - #85 Add checks for property existance during odsm features rebuild.
 

--- a/open_data_schema_map.features.inc
+++ b/open_data_schema_map.features.inc
@@ -95,8 +95,8 @@ function open_data_schema_apis_features_rebuild($module) {
       $existing = open_data_schema_map_api_load($machine_name);
       // @todo add open_data_schema_map_schema_save() function to replace this
       $record = (object) $definition;
-      $record->id = $existing->id;
       if ($existing && isset($existing->id)) {
+        $record->id = $existing->id;
         drupal_write_record('open_data_schema_map', $record, 'id');
       }
       else {


### PR DESCRIPTION
issue: CIVIC-5754

## Description
When building the latest dev branch of dkan you will see this error:

```shell
Trying to get property of non-object in open_data_schema_apis_features_rebuild() (line 98 of                            [notice]
/var/www/dkan/modules/contrib/open_data_schema_map/open_data_schema_map.features.inc).
```

We need to create a check for $existing and $record, you cannot access the 'id' property without checking if the object is null first

```php
function open_data_schema_apis_features_rebuild($module) {
  // Overwrite API in DB from code...
  if ($defaults = features_get_default('open_data_schema_apis', $module)) {
    foreach ($defaults as $machine_name => $definition) {
      $existing = open_data_schema_map_api_load($machine_name);
      // @todo add open_data_schema_map_schema_save() function to replace this
      $record = (object) $definition;
      $record->id = $existing->id;
      if ($existing && isset($existing->id)) {
        drupal_write_record('open_data_schema_map', $record, 'id');
      }
      else {
        drupal_write_record('open_data_schema_map', $record);
      }
    }
  }
}
```

### Steps to reproduce
Build locally or view output on a PROBO build

### Acceptance Criteria
No warnings in the build output with the error above