### PR TITLE
[CIVIC-5631] Site Managers should be able to check POD validation

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,7 @@
+7.x-1.x
+--------
+- 86 Fix validation page permission check using wrong permission name.
+
 7.x-1.12.14
 -----------
 - Add support for validation of data.json files from sites with self-signed certificates.

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -126,7 +126,7 @@ function open_data_schema_map_menu() {
       'title' => $data['title'],
       'page callback' => $data['page callback'],
       'page arguments' => array(),
-      'access arguments' => array('Administer Open Data Schema Mapper'),
+      'access arguments' => array('administer open data schema mapper'),
       'type' => MENU_NORMAL_ITEM,
       'file' => $data['file'],
       'file path' => $data['file path'],


### PR DESCRIPTION
issue: CIVIC-5631

## Description
Site Managers don't have a menu item for checking the POD Validation.

## Steps to Reproduce
- Given I am logged in as a Site Manager
- When I look at the 'Site Configuration' > 'Open Data Schema Mapper' menu
- Then I should see a 'Project Open Data validation' item

## Acceptance Criteria
- Site Managers should be able to use the POD validator via a menu item