### PR TITLE
Update pod_v1_1 to use language key codes rather than labels CIVIC-6063

### DIFF
--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -156,18 +156,17 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
         }
         // Language must display the key not the label.
         if (isset($dataset['language'])) {
-          // List of language code options.
           if (function_exists('dkan_dataset_content_types_allowed_language_values')) {
+            // Convert language label to the key from the list of language code options.
             $values = dkan_dataset_content_types_allowed_language_values();
-            $languages = array();
             foreach ($dataset['language'] as $delta => $value) {
               $key = array_search($dataset['language'][$delta], $values);
               if ($key) {
-                $languages[] = $key;
+                $dataset['language'][$delta] = $key;
               }
-            }
-            if ($languages) {
-              $dataset['language'] = $languages;
+              else {
+                unset($dataset['license'][$delta]);
+              }
             }
           }
         }

--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -5,7 +5,7 @@
  * Provides Schema mapping for Project Open Data.
  */
 
-require_once('podValidator.php');
+require_once 'podValidator.php';
 
 /**
  * Implements hook_open_data_schema_map_validation().
@@ -224,7 +224,8 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
           if (filter_var($dataset['contactPoint']['hasEmail'], FILTER_VALIDATE_EMAIL)) {
             $dataset['contactPoint']['hasEmail'] = 'mailto:' . $dataset['contactPoint']['hasEmail'];
           }
-          // Remove completely if invalid. An empy hasEmail validates while a poorly formed or invalid email does not.
+          // Remove completely if invalid. An empty hasEmail validates
+          // while a poorly formed or invalid email does not.
           else {
             watchdog('open_data_schema_map_od', 'Dataset %dataset contact point email: %email is not valid. Added default value for empty emails.', array('%dataset' => $dataset['title'], '%email' => $dataset['contactPoint']['hasEmail']), WATCHDOG_NOTICE, $link = NULL);
             $dataset['contactPoint']['hasEmail'] = 'mailto:' . variable_get('pod_default_email', 'noemailprovided@usa.gov');
@@ -262,7 +263,7 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
  * - keyword
  * - publisher
  * - contactPoint
- * - accessLevel
+ * - accessLevel.
  */
 function odsm_add_data_JSON_defaults(&$dataset) {
   if ((isset($dataset['title']) && !$dataset['title']) || !isset($dataset['title'])) {
@@ -304,7 +305,7 @@ function open_data_schema_pod_open_data_schema_fill_references($schema_name, &$s
         if (isset($schema['properties'][$key]['anyOf'])) {
           $json = $json . $schema['properties'][$key]['anyOf'][0]['items']['$ref'];
         }
-        elseif(isset($schema['properties'][$key]['$ref'])) {
+        elseif (isset($schema['properties'][$key]['$ref'])) {
           $json = $json . $schema['properties'][$key]['$ref'];
         }
         $json = file_get_contents($json);

--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -160,8 +160,8 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
             // Convert language label to the key from the list of language code options.
             $values = dkan_dataset_content_types_allowed_language_values();
             foreach ($dataset['language'] as $delta => $value) {
-              $key = array_search($dataset['language'][$delta], $values);
-              $dataset['language'][$delta] = $key;
+              $key_language = array_search($dataset['language'][$delta], $values);
+              $dataset['language'][$delta] = $key_language;
             }
           }
         }

--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -161,12 +161,7 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
             $values = dkan_dataset_content_types_allowed_language_values();
             foreach ($dataset['language'] as $delta => $value) {
               $key = array_search($dataset['language'][$delta], $values);
-              if ($key) {
-                $dataset['language'][$delta] = $key;
-              }
-              else {
-                unset($dataset['license'][$delta]);
-              }
+              $dataset['language'][$delta] = $key;
             }
           }
         }

--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -154,6 +154,23 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
             unset($dataset['license']);
           }
         }
+        // Language must display the key not the label.
+        if (isset($dataset['language'])) {
+          // List of language code options.
+          if (function_exists('dkan_dataset_content_types_allowed_language_values')) {
+            $values = dkan_dataset_content_types_allowed_language_values();
+            $languages = array();
+            foreach ($dataset['language'] as $delta => $value) {
+              $key = array_search($dataset['language'][$delta], $values);
+              if ($key) {
+                $languages[] = $key;
+              }
+            }
+            if ($languages) {
+              $dataset['language'] = $languages;
+            }
+          }
+        }
         if (isset($dataset['dataQuality'])) {
           if ($dataset['dataQuality'] == 'TRUE') {
             $dataset['dataQuality'] = (bool) TRUE;


### PR DESCRIPTION
issue: CIVIC-6063

## Description
1. POD validation fails on the language field, it is expecting a key value and is getting the label value.
2. The keys that exist are using underscores and the validator is expecting dashes. (i.e. `en_US`  should be `en-US`)

## Related PRs
https://github.com/NuCivic/dkan/pull/1836
