### PR TITLE
Translate "private" to "non-public" in project open data

### DIFF
--- a/modules/open_data_schema_pod/open_data_schema_pod.module
+++ b/modules/open_data_schema_pod/open_data_schema_pod.module
@@ -137,6 +137,9 @@ function open_data_schema_pod_open_data_schema_map_results_alter(&$result, $mach
           if ($dataset['accessLevel'] == 'restricted') {
             $dataset['accessLevel'] = 'restricted public';
           }
+          if ($dataset['accessLevel'] == 'private') {
+            $dataset['accessLevel'] = 'non-public';
+          }
         }
         if (isset($dataset['temporal']) && $dataset['temporal'] == "/") {
           unset($dataset['temporal']);


### PR DESCRIPTION
We translate "restricted" to "restricted public" in POD v1.1 but "private" is not translated to "non-public". This fixes that.

We should perhaps change the actual key and provide an update hook in the future.

See NuCivic/dkan#2029 for tests/qa