### PR TITLE
2103 - Add Dataset Filtering

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.14
 -------
 - #95 Add UI for odsm cache admin.
+- #2103 Added Dataset Federated Data Filtering
 
 7.x-1.13.4
 ----------

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ When you return to the tags section of the form after saving, you will now see a
 
 ![screen shot 2014-07-16 at 12 22 00 am](https://cloud.githubusercontent.com/assets/512243/5281826/ad5e3eac-7ac6-11e4-8c7d-91076527c84d.png)
 
+### Data Federation Filtering
+
+To exclude specific groups from the API, navigate to `/admin/config/services/odsm/settings` and choose the groups you wish to include.
+
+You must then edit your API and check the **Apply Data Federation Filters** checkbox for the filters to apply to your endpoint.
+
 ## Customizing
 
 ### Adding new schemas

--- a/dkan-module-init.sh
+++ b/dkan-module-init.sh
@@ -59,6 +59,7 @@ else
 fi
 
 ahoy drush en $DKAN_MODULE -y
+ahoy drush updb -y
 
  #Fix for behat bug not recognizing symlinked feature files or files outside it's root. See https://jira.govdelivery.com/browse/CIVIC-1005
 #cp dkan_workflow/test/features/dkan_workflow.feature dkan/test/features/.

--- a/open_data_schema_map.admin.inc
+++ b/open_data_schema_map.admin.inc
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @file
+ * ODSM Admin form functions.
+ */
+
+/**
+ * ODSM Admin Settings Form.
+ *
+ * @param array $form_state
+ *   Form state array
+ *
+ * @return array
+ *   Form array
+ */
+function open_data_schema_map_admin_settings_form($form_state) {
+  $available_filters = _open_data_schema_map_get_available_filters('name');
+  $form['data_json'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Data Federation Filters'),
+    '#description' => t('Use this form to exclude specific groups from federated data. Currently, these filters are available to schemas:') . ' ' . implode(', ', $available_filters),
+  );
+  $group_options = array();
+  $result = db_query("SELECT node.title AS node_title, node.nid AS nid
+    FROM {node} node
+    WHERE ((node.status = '1') AND (node.type IN  ('group')) )
+    ORDER BY node_title ASC"
+  );
+  if ($result) {
+    foreach ($result as $record) {
+      $group_options[$record->nid] = $record->node_title;
+    }
+  }
+  $form['data_json']['odsm_settings_groups'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Groups to include'),
+    '#default_value' => variable_get('odsm_settings_groups', array()),
+    '#options' => $group_options,
+    '#description' => t('If none of the groups are selected, all groups will be included in the data.json. If any of the groups are checked, only datasets belonging to those groups will be included.'),
+  );
+  $form['data_json']['odsm_settings_no_publishers'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Include datasets with no listed publisher in the data.json.'),
+    '#description' => t('If this option is selected, datasets with no listed publisher will be given the default publisher name.'),
+    '#default_value' => variable_get('odsm_settings_no_publishers', 1),
+  );
+
+  return system_settings_form($form);
+}

--- a/open_data_schema_map.install
+++ b/open_data_schema_map.install
@@ -71,7 +71,7 @@ function open_data_schema_map_schema() {
         'description' => 'Output Format.',
         'type' => 'varchar',
         'length' => 20,
-        'not null' => True,
+        'not null' => TRUE,
         'default' => 'json',
       ),
       'endpoint' => array(
@@ -87,6 +87,13 @@ function open_data_schema_map_schema() {
         'size' => 'big',
         'serialize' => TRUE,
       ),
+      'filter_enabled' => array(
+        'description' => 'Whether Data Federation Filter is enabled.',
+        'type' => 'int',
+        'not null' => TRUE,
+        'size' => 'tiny',
+        'default' => 0,
+      ),
     ),
     'primary key' => array('id'),
   );
@@ -95,24 +102,40 @@ function open_data_schema_map_schema() {
 
 
 /**
+ * Ensures that the output format field is in the table.
  *
- * Ensures that the output format field is in the table
  * Also sets outputformat to 'json' for all existing entries
- *
  */
-
 function open_data_schema_map_update_7001() {
 
   $column = array(
     'type' => 'varchar',
     'description' => "Output Format",
     'length' => 20,
-    'not null' => True,
+    'not null' => TRUE,
     'default' => 'json',
   );
 
   $data_table_name = 'open_data_schema_map';
   if (!db_field_exists('open_data_schema_map', 'outputformat')) {
     db_add_field($data_table_name, 'outputformat', $column);
+  }
+}
+
+/**
+ * Ensures that the filter_enabled field is in the table.
+ */
+function open_data_schema_map_update_7002() {
+  $column = array(
+    'description' => 'Whether Data Federation Filter is enabled.',
+    'type' => 'int',
+    'not null' => TRUE,
+    'size' => 'tiny',
+    'default' => 0,
+  );
+
+  $data_table_name = 'open_data_schema_map';
+  if (!db_field_exists('open_data_schema_map', 'filter_enabled')) {
+    db_add_field($data_table_name, 'filter_enabled', $column);
   }
 }

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -10,10 +10,16 @@ require_once $module_path . '/open_data_schema_map.file_cache.inc';
 
 define('OPEN_DATA_SCHEMA_MAP_ADMIN_PATH', 'admin/config/services/odsm');
 
+/**
+ * Class OpenDataSchemaMapException
+ */
 class OpenDataSchemaMapException extends Exception {
+  private $data;
 
   /**
    * Override Exception constructor to add data parameter.
+   *
+   * {@inheritdoc}
    */
   public function __construct($message, $code = 0, $data = NULL) {
     parent::__construct($message, $code);
@@ -207,16 +213,24 @@ function open_data_schema_map_help($path, $arg) {
       return t('Create APIs using Drupal entities that map to Open Data specifications. See !docs for more instructions.',
      array('!docs' => l(t('documentation'), 'https://github.com/NuCivic/open_data_schema_map#open-data-schema-map')));
   }
+  return NULL;
 }
 
 /**
  * Provides form type from field type.
+ *
+ * @param string $field_type
+ *   Field type
+ *
+ * @return string
+ *   Form type
  */
 function open_data_schema_map_form_field_type($field_type) {
   switch ($field_type) {
     case "string":
       return 'textfield';
   }
+  return '';
 }
 
 /**
@@ -230,6 +244,9 @@ function open_data_schema_map_form_field_type($field_type) {
  *   $api object which is passed around because procedural.
  * @param array $defaults
  *   Array of defaults which matches up with the $schema.
+ *
+ * @return array
+ *   Form array
  */
 function open_data_schema_map_form_recursion(&$form, $schema, $api, $defaults = NULL) {
   $entity_ref_fields = open_data_schema_map_entity_ref_fields($api->type, $api->bundle);
@@ -277,6 +294,11 @@ function open_data_schema_map_form_recursion(&$form, $schema, $api, $defaults = 
 
 /**
  * Recursive function that walks throw tokens to output rows.
+ *
+ * @param array $rows
+ *   Output rows
+ * @param array $token_info
+ *   Tokens
  */
 function open_data_schema_map_token_rows(&$rows, $token_info) {
   if (isset($token_info['children'])) {
@@ -302,6 +324,12 @@ function open_data_schema_map_token_rows(&$rows, $token_info) {
 
 /**
  * Creates token tree for single token.
+ *
+ * @param string $token
+ *   Token
+ *
+ * @return string
+ *   Rendered token
  */
 function open_data_schema_map_token_tree($token) {
   module_load_include('inc', 'token', 'token.pages');
@@ -342,7 +370,7 @@ function open_data_schema_map_token_tree($token) {
     $element['#attributes']['class'][] = 'token-click-insert';
     return drupal_render($element);
   }
-
+  return '';
 }
 
 /**
@@ -366,6 +394,9 @@ function open_data_schema_map_api_table() {
  *
  * @param string $machine_name
  *   API machine name.
+ *
+ * @return bool
+ *   Returns FALSE
  */
 function open_data_schema_map_api_exist($machine_name) {
   return FALSE;
@@ -412,10 +443,17 @@ function open_data_schema_map_api_load($machine_name) {
     $record->arguments = unserialize($record->arguments);
     return $record;
   }
+  return NULL;
 }
 
 /**
  * Loads schema from file.
+ *
+ * @param string $schema_name
+ *   Schema name
+ *
+ * @return array
+ *   Schema array
  */
 function open_data_schema_map_schema_load($schema_name) {
   $schemas = &drupal_static(__FUNCTION__, array());
@@ -437,11 +475,11 @@ function open_data_schema_map_schema_load($schema_name) {
 /**
  * Retrieves public, published dataset nodes.
  *
- * @param string $api
+ * @param object $api
  *   Api object.
- * @param string $limit
+ * @param int $limit
  *   Number of results to return.
- * @param string $offset
+ * @param int $offset
  *   Offset of results to return.
  * @param array $args
  *   - query: current value of query.
@@ -495,6 +533,12 @@ function open_data_schema_map_endpoint_query($api, $limit = 0, $offset = 0, $arg
 
 /**
  * Returns array from token.
+ *
+ * @param string $token
+ *   Token
+ *
+ * @return array
+ *   Array from token
  */
 function open_data_schema_map_discover_field($token) {
   $token = rtrim(trim($token, '['), ']');
@@ -503,6 +547,12 @@ function open_data_schema_map_discover_field($token) {
 
 /**
  * Discovers callback for argument options.
+ *
+ * @param string $id
+ *   Argument option
+ *
+ * @return string
+ *   Callback
  */
 function open_data_schema_map_schema_options_callback($id) {
   $schema_types = open_data_schema_map_schema_types();
@@ -513,8 +563,15 @@ function open_data_schema_map_schema_options_callback($id) {
   }
   return NULL;
 }
+
 /**
  * Discovers callback for schema type.
+ *
+ * @param string $id
+ *   Schema type
+ *
+ * @return string
+ *   Callback
  */
 function open_data_schema_map_schema_types_callback($id) {
   $schema_types = open_data_schema_map_schema_types();
@@ -549,6 +606,18 @@ function open_data_schema_map_schema_types() {
 
 /**
  * Creates argument form.
+ *
+ * @param int $num_args
+ *   Number of args
+ * @param array $options
+ *   Options array
+ * @param array $defaults
+ *   Defaults array
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Form array
  */
 function open_data_schema_map_args_form($num_args, $options, $defaults, $api) {
   $map = $api->mapping;
@@ -611,6 +680,9 @@ function open_data_schema_map_args_form($num_args, $options, $defaults, $api) {
 
 /**
  * Special fields for arguments.
+ *
+ * @return array
+ *   Array of arguments
  */
 function open_data_schema_map_special_arguments() {
   return array(
@@ -626,6 +698,8 @@ function open_data_schema_map_special_arguments() {
  *   Entity machine name.
  * @param string $bundle
  *   Bundle machine name.
+ * @param array $ref_fields
+ *   List of fields
  *
  * @return array
  *   Array of entity reference or similar fields.
@@ -658,6 +732,16 @@ function open_data_schema_map_entity_ref_fields($entity, $bundle, $ref_fields = 
 
 /**
  * Creates form from JSON 4 schema.
+ *
+ * @param array $schema
+ *   Schema array
+ * @param object $api
+ *   API object
+ * @param array $defaults
+ *   Array of defaults
+ *
+ * @return array
+ *   Form array
  */
 function open_data_schema_map_json_4($schema, $api, $defaults) {
   $form = array();
@@ -740,6 +824,15 @@ function open_data_schema_map_json_4($schema, $api, $defaults) {
 
 /**
  * Constructs form for json schema 3.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $schema
+ *   Schema
+ * @param object $api
+ *   API object
+ * @param array $defaults
+ *   Array of defaults
  */
 function open_data_schema_map_json_3_recursion(&$form, $schema, $api, $defaults = NULL) {
   foreach ($schema as $item => $data) {
@@ -786,6 +879,16 @@ function open_data_schema_map_json_3_recursion(&$form, $schema, $api, $defaults 
 
 /**
  * Creates form from JSON 3 schema.
+ *
+ * @param array $schema
+ *   Schema array
+ * @param object $api
+ *   API object
+ * @param array $defaults
+ *   Array of defaults
+ *
+ * @return array
+ *   Form array
  */
 function open_data_schema_map_json_3($schema, $api, $defaults) {
   $form = array();
@@ -799,6 +902,12 @@ function open_data_schema_map_json_3($schema, $api, $defaults) {
 
 /**
  * Creates option list from available arguments.
+ *
+ * @param array $schema
+ *   Schema array
+ *
+ * @return array
+ *   Options array
  */
 function open_data_schema_mapper_args_options_json_4($schema) {
   $options = array();
@@ -810,6 +919,12 @@ function open_data_schema_mapper_args_options_json_4($schema) {
 
 /**
  * Creates option list from available arguments.
+ *
+ * @param array $schema
+ *   Schema array
+ *
+ * @return array
+ *   Options array
  */
 function open_data_schema_mapper_args_options_json_3($schema) {
   $options = array();
@@ -821,8 +936,20 @@ function open_data_schema_mapper_args_options_json_3($schema) {
 
 /**
  * Wrapper around token_replace.
+ *
+ * @param string $token
+ *   Token
+ * @param string $entity_type
+ *   Entity Type
+ * @param object $entity
+ *   Entity object
+ *
+ * @return string
+ *   Token replaced string
  */
 function open_data_schema_mapper_token_replace($token, $entity_type, $entity) {
+  $rend_tokens = array();
+
   // Does the token have an "or".
   $output = '';
   if (preg_match('/\] \|\| \[/', $token)) {
@@ -850,6 +977,16 @@ function open_data_schema_mapper_token_replace($token, $entity_type, $entity) {
 
 /**
  * Provides working arguments by validating fields and queries.
+ *
+ * @param array $map
+ *   Map array
+ * @param array $queries
+ *   Queries array
+ * @param array $args
+ *   Args array
+ *
+ * @return array
+ *   Array of args
  */
 function open_data_schema_map_endpoint_args(&$map, $queries, $args = array()) {
   $output = array();
@@ -874,11 +1011,18 @@ function open_data_schema_map_endpoint_args(&$map, $queries, $args = array()) {
 
 /**
  * Process entities using api.
+ *
+ * @param array $ids
+ *   IDs array
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Array of processed entities
  */
 function open_data_schema_map_endpoint_process_map($ids, $api) {
   $output = array();
   if ($ids) {
-    $schema = open_data_schema_map_schema_load($api->api_schema);
     foreach ($ids as $key => $id) {
       $result = array();
       $entity = entity_load_single($api->type, $id);
@@ -891,6 +1035,15 @@ function open_data_schema_map_endpoint_process_map($ids, $api) {
 
 /**
  * Walks through map adding to results.
+ *
+ * @param array $result
+ *   Results array
+ * @param array $map
+ *   Map array
+ * @param string $type
+ *   API type
+ * @param object $entity
+ *   Entiy object
  */
 function open_data_schema_map_endpoint_process_map_recursion(&$result, $map, $type, $entity) {
   foreach ($map as $api_field => $token) {
@@ -908,7 +1061,6 @@ function open_data_schema_map_endpoint_process_map_recursion(&$result, $map, $ty
         unset($token['odsm_entity_reference']);
         if ($values) {
           foreach ($values as $num => $item) {
-            $subvalue = array();
             $sub_result = array();
             foreach ($token as $subfield => $subtoken) {
               $subtoken['value'] = str_replace('Nth', $num, $subtoken['value']) ? str_replace('Nth', $num, $subtoken['value']) : $subtoken['value'];
@@ -947,6 +1099,18 @@ function open_data_schema_map_endpoint_process_map_recursion(&$result, $map, $ty
 
 /**
  * Processes individual field.
+ *
+ * @param string $api_field
+ *   API field
+ * @param array $token
+ *   Token array
+ * @param string $type
+ *   API type
+ * @param object $entity
+ *   Entity object
+ *
+ * @return array
+ *   Array of results
  */
 function open_data_schema_map_endpoint_process_field($api_field, $token, $type, $entity) {
   $result = array();
@@ -960,6 +1124,14 @@ function open_data_schema_map_endpoint_process_field($api_field, $token, $type, 
 
 /**
  * Checks output for expected types and adjusts.
+ *
+ * @param string $value
+ *   Value
+ * @param array $token
+ *   Token array
+ *
+ * @return mixed
+ *   Casted value
  */
 function open_data_schema_mapper_field_type_check($value, $token) {
   if ($token['type'] == 'array') {
@@ -973,7 +1145,7 @@ function open_data_schema_mapper_field_type_check($value, $token) {
     }
   }
   elseif ($token['type'] == 'boolean') {
-    $value = (boolean)$value;
+    $value = (boolean) $value;
   }
   elseif ($token['type'] == 'object') {
     // TODO: make object.
@@ -983,12 +1155,19 @@ function open_data_schema_mapper_field_type_check($value, $token) {
 
 /**
  * Grabs special from arguments and removes it.
+ *
+ * @param array $args
+ *   Args array
+ * @param string $type
+ *   API type
+ *
+ * @return string
+ *   Arg
  */
 function open_data_schema_map_endpoint_special_arg(&$args, $type) {
   $value = '';
   foreach ($args as $num => $arg) {
     if ($arg['field'] == $type) {
-      $value = $args[$num];
       unset($args[$num]);
       return $arg['query'];
     }
@@ -1002,14 +1181,14 @@ function open_data_schema_map_endpoint_special_arg(&$args, $type) {
  */
 function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
   if ($arg['token']['value'] == '[node:url:arg:last]' || $arg['token']['value'] == '[node:url:args:last]') {
-    // Query against a like statement to reduce forloop 
-    $result = db_select('url_alias', 'url')
+    // Query against a like statement to reduce forloop.
+    $results = db_select('url_alias', 'url')
               ->fields('url', array('source', 'alias'))
               ->condition('alias', '%/' . $arg['query'], 'LIKE')
               ->execute()
-              ->fetchAll(); 
+              ->fetchAll();
     $field[1] = 'nid';
-    foreach ($result as $result) {
+    foreach ($results as $result) {
       $alias = explode('/', $result->alias);
       if ($alias[count($alias) - 1] == $arg['query']) {
         $nid = explode('/', $result->source);
@@ -1022,7 +1201,7 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
       404,
       array(
         '__type' => 'Query Error',
-        'name_or_id' => t('Query \'!query\' doesn\'t return results', array('!query' => $arg['query'])),
+        'name_or_id' => t("Query '!query' doesn't return results", array('!query' => $arg['query'])),
       )
     );
   }
@@ -1045,6 +1224,16 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
 
 /**
  * Function that renders and odsm api for endpoint.
+ *
+ * @param object $api
+ *   API object
+ * @param array $query
+ *   Query array
+ * @param array $queries
+ *   Queries array
+ *
+ * @return array
+ *   Array of results/headers
  */
 function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
   if (!isset($queries)) {
@@ -1109,26 +1298,40 @@ function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
 
 /**
  * Discovers additional fields.
+ *
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Array of additional fields
  */
 function open_data_schema_map_additional_fields($api) {
   $tokens = array();
+  $additional_fields = array();
   foreach ($api->mapping as $schema_id => $item) {
     if (isset($item['value']) && $item['value'] && !is_array($item['value'])) {
       $tokens[] = $item['value'];
     }
   }
-  $unsused_fields = array();
   $fields = field_info_instances('node', 'dataset');
   foreach ($fields as $field_name => $instance) {
     if (!in_array('[node:' . $field_name . ']', $tokens)) {
-      $addtional_fields[] = $field_name;
+      $additional_fields[] = $field_name;
     }
   }
-  return $addtional_fields;
+  return $additional_fields;
 }
 
 /**
  * Adds additional fields to mapping.
+ *
+ * @param array $fields
+ *   Fields array
+ * @param object $api
+ *   API object
+ *
+ * @return object
+ *   Updated API object
  */
 function open_data_schema_map_additional_fields_add($fields, $api) {
   foreach ($fields as $field_name) {
@@ -1138,8 +1341,14 @@ function open_data_schema_map_additional_fields_add($fields, $api) {
   return $api;
 }
 
- /*
+/**
  * Adds node links to errors.
+ *
+ * @param array $rows
+ *   Array of error rows
+ *
+ * @return array
+ *   Error rows with node links added
  */
 function open_data_schema_validation_process_errors($rows) {
   foreach ($rows as $key => $row) {
@@ -1152,7 +1361,7 @@ function open_data_schema_validation_process_errors($rows) {
     else {
       $node = $ids[$row['id']];
     }
-    $rows[$key]['title'] = l($node->title,'node/' . $node->nid);
+    $rows[$key]['title'] = l($node->title, 'node/' . $node->nid);
   }
   return $rows;
 }
@@ -1179,7 +1388,7 @@ function open_data_schema_map_tokens_alter(array &$replacements, array $context)
     $replacements['[node:field-frequency]'] = open_data_schema_map_accrual_iso_8601_value($replacements['[node:field-frequency]']);
   }
   if (isset($replacements['[node:field-data-dictionary]'])) {
-    //Check if is a url.
+    // Check if is a url.
     $url = check_url($context['data']['node']->field_data_dictionary[LANGUAGE_NONE][0]['value']);
     $output = valid_url($url, TRUE) ? $url : $context['data']['node']->field_data_dictionary[LANGUAGE_NONE][0]['value'];
     $replacements['[node:field-data-dictionary]'] = $output;
@@ -1188,6 +1397,12 @@ function open_data_schema_map_tokens_alter(array &$replacements, array $context)
 
 /**
  * Provides value for human readable name.
+ *
+ * @param string $name
+ *   Name
+ *
+ * @return string
+ *   Human readable name
  */
 function open_data_schema_map_accrual_iso_8601_value($name) {
   if ($name == 'Annually') {
@@ -1204,6 +1419,9 @@ function open_data_schema_map_accrual_iso_8601_value($name) {
 
 /**
  * Provides iso 8601 accrual periodicity.
+ *
+ * @return array
+ *   Array of iso values
  */
 function open_data_schema_map_accrual_iso_8601() {
   return array(

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -107,6 +107,15 @@ function open_data_schema_map_menu() {
     'file' => 'open_data_schema_map.pages.inc',
     'type' => MENU_LOCAL_ACTION,
   );
+  $items[$pre . '/settings'] = array(
+    'title' => 'Settings',
+    'description' => 'Open Data Schema Map Settings',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('open_data_schema_map_admin_settings_form'),
+    'access arguments' => array('administer open data schema mapper'),
+    'file' => 'open_data_schema_map.admin.inc',
+    'type' => MENU_LOCAL_ACTION,
+  );
   $items[$pre . '/edit/%open_data_schema_map_api'] = array(
     'title' => 'Edit API',
     'description' => 'Edit an existing API Endpoint',
@@ -1444,4 +1453,170 @@ function open_data_schema_map_accrual_iso_8601() {
     'Three times a year' => 'R/P4M',
     'Weekly' => 'R/P1W',
   );
+}
+
+/**
+ * Implements hook_open_data_schema_map_results_alter().
+ */
+function open_data_schema_map_open_data_schema_map_results_alter(&$result, $api_machine_name, $schema) {
+  $api = open_data_schema_map_api_load($api_machine_name);
+  if ($api->filter_enabled && in_array($api_machine_name, _open_data_schema_map_get_available_filters('machine_name'))) {
+    $ghosts = 0;
+    $itemcount = count($result);
+    $include_datasets_with_no_publishers = variable_get('odsm_settings_no_publishers', 1);
+    watchdog('open_data_schema_map', "Generating data.json: about to iterate over $itemcount datasets.");
+    // Determine whether to filter the data.json feed by publisher.
+    $publishers = array();
+    $included_agency_nids = variable_get('odsm_settings_groups', array());
+    $filter_by_publisher = FALSE;
+    // If none of the groups are selected, don't filter the data.json by
+    // publisher. If any of the groups are checked, only those groups
+    // will be included.
+
+    // NIDs are zero if unchecked, so use sum.
+    if (array_sum($included_agency_nids)) {
+      $filter_by_publisher = TRUE;
+      $publishers = array();
+      $agencies = db_query("SELECT node.title AS node_title, node.nid AS nid
+        FROM {node} node
+        WHERE ((node.status = '1') AND (node.type IN  ('group')) )
+        ORDER BY node_title ASC"
+      );
+      foreach ($agencies as $agency) {
+        if (in_array($agency->nid, $included_agency_nids)) {
+          $publishers[] = htmlentities($agency->node_title);
+        }
+      }
+    }
+    foreach ($result as $key => $dataset) {
+      // Exclude "ghost datasets," i.e., datasets with no title.
+      if (is_array($dataset) && !isset($dataset['title'])) {
+        unset($result[$key]);
+        watchdog('open_data_schema_map', 'Ghost dataset: <pre>@key</pre>', array('@key' => print_r($result[$key])), TRUE);
+        $ghosts++;
+        continue;
+      }
+      // Remove datasets that don't have a publisher.
+      elseif (!$include_datasets_with_no_publishers && !isset($dataset['publisher']['name'])) {
+        unset($result[$key]);
+        continue;
+      }
+      // Remove datasets that are not on the included publishers list.
+      elseif ($filter_by_publisher && isset($dataset['publisher']['name']) && !_open_data_schema_map_settings_contains($dataset['publisher']['name'], $publishers)) {
+        unset($result[$key]);
+        continue;
+      }
+
+      // Do some cleanup to improve data.json validation.
+      if (isset($dataset['@type']) && $dataset['@type'] == 'dcat:Dataset') {
+        // Default hasEmail to site email.
+        if (isset($dataset['contactPoint'])
+          && isset($dataset['contactPoint']['hasEmail'])
+          && $dataset['contactPoint']['hasEmail'] == 'mailto:') {
+          $result[$key]['contactPoint']['hasEmail'] .= variable_get('site_mail');
+        }
+        if (!isset($dataset['keyword'])) {
+          if (isset($dataset['publisher']['name'])) {
+            $result[$key]['keyword'] = array(_open_data_schema_map_keyword_string($dataset['publisher']['name']));
+          }
+          else {
+            $result[$key]['keyword'] = array('health');
+          }
+        }
+        if (!isset($dataset['description'])) {
+          $result[$key]['description'] = t('No description provided');
+        }
+        if (isset($dataset['distribution'])) {
+          foreach ($dataset['distribution'] as $num => $dist) {
+            if (empty($dist['mediaType'])) {
+              $result[$key]['distribution'][$num]['mediaType'] = 'application/unknown';
+            }
+            if (empty($dist['downloadURL']) || $dist['downloadURL'] == 'http://') {
+              unset($result[$key]['distribution'][$num]['downloadURL']);
+            }
+            if (!$dist['format']) {
+              unset($result[$key]['distribution'][$num]['format']);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+/**
+ * Get available filters.
+ *
+ * @param string $return_type
+ *   Valid values are 'machine_name', 'api_schema', 'name'
+ *
+ * @return array
+ *   Array of filters values of $return_type
+ */
+function _open_data_schema_map_get_available_filters($return_type = 'machine_name') {
+  $available_filters = array();
+  $available_filters_machine_name = array(
+    'data_json_1_1',
+    'dcat_v1_1',
+    'dcat_v1_1_json',
+  );
+
+  // Validate return_type.
+  if (!in_array($return_type, array('machine_name', 'api_schema', 'name'))) {
+    watchdog('open_data_schema_map',
+      'Invalid return type @return_type specified for _open_data_schema_map_get_available_filters()',
+      array('@return_type' => $return_type)
+    );
+    return NULL;
+  }
+
+  $apis = open_data_schema_map_api_load_all();
+  foreach ($apis as $num => $api) {
+    if (in_array($api->machine_name, $available_filters_machine_name)) {
+      $available_filters[] = $api->$return_type;
+    }
+  }
+
+  return $available_filters;
+}
+
+/**
+ * Utility function to see if an agency is in a list of publishers.
+ *
+ * @param string $agency_string
+ *   A string with the name of the agency or agencies that publish a dataset.
+ * @param array $publishers
+ *   An array with the names of publishers to be included.
+ *
+ * @return bool
+ *   Boolean (true if $agency_string contains one or more of the publishers).
+ */
+function _open_data_schema_map_settings_contains($agency_string, array $publishers) {
+  foreach ($publishers as $publisher) {
+    if (stripos($agency_string, $publisher) !== FALSE) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/**
+ * String utility function.
+ *
+ * @param string $string
+ *   Input string
+ *
+ * @return string
+ *   Keyword alphanumeric string w/only dashes.
+ */
+function _open_data_schema_map_keyword_string($string) {
+  // Lower case everything.
+  $string = strtolower($string);
+  // Make alphanumeric (removes all other characters).
+  $string = preg_replace("/[^a-z0-9_\s-]/", "", $string);
+  // Clean up multiple dashes or whitespaces.
+  $string = preg_replace("/[\s-]+/", " ", $string);
+  // Convert whitespaces and underscore to dash.
+  $string = preg_replace("/[\s_]/", "-", $string);
+  return $string;
 }

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -56,6 +56,16 @@ function open_data_schema_map_page_overview() {
 
 /**
  * Callback for delete page.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Form Array
  */
 function open_data_schema_map_delete(array $form, array &$form_state, $api = NULL) {
   if (isset($api->callback)) {
@@ -73,6 +83,11 @@ function open_data_schema_map_delete(array $form, array &$form_state, $api = NUL
 
 /**
  * Submit function for deleting an API.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
  */
 function open_data_schema_map_delete_submit(array $form, array &$form_state) {
   $api = $form['#api'];
@@ -90,8 +105,19 @@ function open_data_schema_map_delete_submit(array $form, array &$form_state) {
 
 /**
  * Callback for primary menu page.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Form Array
  */
 function open_data_schema_map_manage(array $form, array &$form_state, $api = NULL) {
+  $entity_list = array();
   if (isset($api->callback)) {
     $form['in_code'] = array(
       '#type' => 'item',
@@ -334,6 +360,14 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
 
 /**
  * Creates form for schema fields.
+ *
+ * @param array $schema
+ *   Schema array
+ * @param object $api
+ *   API Object
+ *
+ * @return array
+ *   Form array
  */
 function open_data_schema_map_schema_map_form($schema, $api) {
   $function = open_data_schema_map_schema_types_callback($schema['$schema']);
@@ -347,6 +381,14 @@ function open_data_schema_map_schema_map_form($schema, $api) {
 
 /**
  * Form AJAX handler.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
+ *
+ * @return array
+ *   Bundle array
  */
 function open_data_schema_map_bundle_ajax_callback(array $form, array &$form_state) {
   return $form['bundle'];
@@ -354,6 +396,14 @@ function open_data_schema_map_bundle_ajax_callback(array $form, array &$form_sta
 
 /**
  * Form AJAX handler.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
+ *
+ * @return array
+ *   Arguments array
  */
 function open_data_schema_mapper_args_ajax_callback(array $form, array &$form_state) {
   return $form['arguments'];
@@ -361,6 +411,11 @@ function open_data_schema_mapper_args_ajax_callback(array $form, array &$form_st
 
 /**
  * Submit function for api map.
+ *
+ * @param array $form
+ *   Form array
+ * @param array $form_state
+ *   Form state array
  */
 function open_data_schema_map_manage_submit($form, $form_state) {
   $db_schema = drupal_get_schema('open_data_schema_map');
@@ -403,6 +458,11 @@ function open_data_schema_map_manage_submit($form, $form_state) {
 
 /**
  * Adds field type to field definition.
+ *
+ * @param array $values
+ *   Values array
+ * @param array $mapping
+ *   Mapping array
  */
 function open_data_schema_map_add_type(&$values, $mapping) {
   foreach ($values as $api_field => $token) {
@@ -418,6 +478,9 @@ function open_data_schema_map_add_type(&$values, $mapping) {
 
 /**
  * Main endpoint callback.
+ *
+ * @param object $api
+ *   API object
  */
 function open_data_schema_map_endpoint($api) {
   // Start by setting the content type header based on the API settings.

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -318,6 +318,15 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     }
     $form['mapping'] = $form['mapping'] + open_data_schema_map_schema_map_form($schema, $api);
 
+    if (in_array($api->machine_name, _open_data_schema_map_get_available_filters('machine_name'))) {
+      $form['filter_enabled'] = array(
+        '#type' => 'checkbox',
+        '#title' => t('Apply Data Federation Filters'),
+        '#description' => t('Check to apply filters configured in the') . ' ' . l(t('Data Federation Filters'), '/admin/config/services/odsm/settings') . ' ' . t('settings'),
+        '#weight' => 6,
+      );
+    }
+
     // Load defaults.
     $form['name']['#default_value'] = $api->name;
     $form['machine_name']['#default_value'] = $api->machine_name;
@@ -328,12 +337,12 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
     $form['enabled']['#default_value'] = $api->enabled;
     $form['api_schema']['#default_value'] = $api->api_schema;
     $form['arguments']['#default_value'] = $api->arguments;
+    $form['filter_enabled']['#default_value'] = $api->filter_enabled;
 
     $form['id'] = array(
       '#type' => 'hidden',
       '#value' => $api->id,
     );
-
   }
   if ($api) {
     $form['submit'] = array(


### PR DESCRIPTION
GetDKAN/dkan#2103 - Adds Data Federation filtering for groups

 ## Description
Adds Federated Data Filtering capability to admin UI. See README.md for instructions on setup.

 ## QA Steps
- [x] PHPUnit tests verify filtering functions in CircleCI (6 tests should have passed under Test section)
- [x] Login as admin, verify /admin/config/services/odsm/settings allows you to configure filter settings
- [x] Navigate to /admin/config/services/odsm/edit/dcat_v1_1_json and verify there is an "Enable Filter" checkbox (Unfortunately Probo runs out memory to test this)
