### PR TITLE
Restrict the render depth of the API endpoint editor

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -343,7 +343,8 @@ function open_data_schema_map_token_rows(&$rows, $token_info) {
 function open_data_schema_map_token_tree($token) {
   module_load_include('inc', 'token', 'token.pages');
 
-  $tree = token_build_tree('node');
+  $options = array('depth' => 3);
+  $tree = token_build_tree('node',$options);
   if (!isset($tree[$token])) {
     $token = substr($token, 0, -1) . ":?]";
   }

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -309,6 +309,7 @@ function open_data_schema_map_manage(array $form, array &$form_state, $api = NUL
       $form['mapping']['token_help']['tokens'] = array(
         '#theme' => 'token_tree',
         '#token_types' => array('node'),
+        '#recursion_limit' => 3
       );
       $form['mapping']['token_help']['help'] = array(
         '#type' => 'item',


### PR DESCRIPTION
This improves menu and page load times significantly to restrict the
depth of the token tree from 4 to 3 when rendering the Endpoint API edit
form.

When trying to edit an ODSM API endpoint on our site, we were running into issues with memory exhaustion, and MySQL packet size.

We had to set the PHP's memory_limit to 1G and MySQL's max_allowed_packet to 128M in order for the page to render without exceptions.

We were able to trace back the main performance issues to the rendering of the token tables, both using the direct theme call in the render array generated in open_data_schema_map_manage() and also the call to open_data_schema_map_token_tree().

In both cases the calls are rendering the token tables and using the default depth of 4. In our case, reducing the depth to 3 allowed us to return both settings above to their normal levels (256M and 64M) and still render the page.
