### PR TITLE
Lock symfonyserializer to 3.4

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.14.1
 ----------
+- #110 Lock symfonyserializer library to the 3.4.2 tag
 - #109 Fixed id argument for package_show and group_package_show in ckan endpoints
 - #65 Added DCAT / POD URL Validation.
 

--- a/open_data_schema_map.make
+++ b/open_data_schema_map.make
@@ -4,7 +4,7 @@ api = 2
 libraries[symfonyserializer][type] = libraries
 libraries[symfonyserializer][download][type] = "git"
 libraries[symfonyserializer][download][url] = "https://github.com/symfony/serializer.git"
-libraries[symfonyserializer][download][branch] = master
+libraries[symfonyserializer][download][tag] = v3.4.2
 
 libraries[json-schema][type] = libraries
 libraries[json-schema][download][type] = "git"


### PR DESCRIPTION
connects getdkan/dkan#2277

- Symfony version 4.0.0 requires PHP 7.1.3 (https://symfony.com/doc/current/reference/requirements.html).
- The ?string notation in symfony version 4.0.0 is valid in PHP 7.1 but not in previous PHP versions.
- RDF view on datasets are broken if using symfony 4.0

>When you try to view the rdf view of the dataset then you get a 404 error. After checking the logs, this happens because there are some parsing errors in: profiles/dkan/libraries/symfonyserializer/Normalizer/AbstractObjectNormalizer.php

>More specifically in lines 235 and 346 there is a ? in front of string in function declaration.

>ParseError: syntax error, unexpected '?', expecting variable (T_VARIABLE) in /profiles/dkan/libraries/symfonyserializer/Normalizer/AbstractObjectNormalizer.php).

>If you remove this then it works fine.

## QA steps
Use probo QA site at https://github.com/GetDKAN/dkan/pull/2300
- Navigate to a dataset node
- Click the `RDF` button under **Other Access**
- You should see xml output and not an error message

![demo_getdkan_com_dataset_florida-bike-lanes_xml](https://user-images.githubusercontent.com/314172/34392785-ff7d30c4-eb13-11e7-9baf-da3659f4f39a.png)