### PR TITLE
Print msgs odsm-filecache

### DIFF
--- a/open_data_schema_map.file_cache.inc
+++ b/open_data_schema_map.file_cache.inc
@@ -82,19 +82,19 @@ function open_data_schema_map_file_cache_exits($api, $arguments = array()) {
 function open_data_schema_map_file_cache_endpoint($machine_name) {
   $api = open_data_schema_map_api_load($machine_name);
   if (isset($api)) {
-    watchdog('open_data_schema_map', 'api present and loaded', WATCHDOG_INFO);
+    watchdog('open_data_schema_map', 'api present and loaded', [], WATCHDOG_INFO);
     $filename = open_data_schema_map_file_cache_name_helper($api);
     // This will only work for data.json v1.1 right now.
-    watchdog('open_data_schema_map', 'Beginning processing for endpoint (this could take a while)', WATCHDOG_INFO);
+    watchdog('open_data_schema_map', 'Beginning processing for endpoint (this could take a while)', [], WATCHDOG_INFO);
     $render = open_data_schema_map_render_api($api);
     $result = $render['result'];
 
     // Load the correct output format, render results, and write to a file.
     if ($output_format = open_data_schema_map_output_format_load($api->outputformat)) {
       $response = $output_format['callback']($api, $result);
-      watchdog('open_data_schema_map', "Saving $filename", WATCHDOG_INFO);
+      watchdog('open_data_schema_map', "Saving $filename", [], WATCHDOG_INFO);
       file_save_data($response, $filename, FILE_EXISTS_REPLACE);
-      watchdog('open_data_schema_map', "$filename saved", WATCHDOG_INFO);
+      watchdog('open_data_schema_map', "$filename saved", [], WATCHDOG_INFO);
     }
   }
 }

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1035,11 +1035,20 @@ function open_data_schema_map_endpoint_args(&$map, $queries, $args = array()) {
 function open_data_schema_map_endpoint_process_map($ids, $api) {
   $output = array();
   if ($ids) {
+    $total = count($ids);
+    $count = 0;
+    $index = 0;
     foreach ($ids as $key => $id) {
       $result = array();
       $entity = entity_load_single($api->type, $id);
       open_data_schema_map_endpoint_process_map_recursion($result, $api->mapping, $api->type, $entity);
       $output[] = $result;
+      $count++;
+      $index++;
+      if ($count == 100 || $index == $total) {
+        drush_log("Processed $index out of $total items", "ok");
+        $count = 0;
+      }
     }
   }
   return $output;


### PR DESCRIPTION
## Description
When running `drush odsm-filecache data_json_1_1` remotely on a site with thousands of datasets, the process takes more than 15 minutes without printing messages so the SSH connection is closed and the process fails.
https://github.com/nucivic/dkan_management/issues/159

## How to replicate
- Run `drush odsm-filecache data_json_1_1`.
- The following messages appear in the terminal:
```
strtr(): The second argument is not an array syslog.module:115                                              [warning]
strtr(): The second argument is not an array syslog.module:115                                              [warning]
```

- If run on acquia environment, the SSH session is closed after 15min and the command fails.

## How to test
- Run `drush odsm-filecache data_json_1_1`.
- [ ] Message `strtr(): The second argument is not an array syslog.module:115 [warning]` should not appear.
- [ ] There should appear messages in the terminal showing the amount of items processed every 100 items.
- [ ] If run on acquia environment, the SSH session should not be broken after 15min, the command should finish correctly.
