### PR TITLE
Links to JSON/RDF lead to 503 errors

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1046,7 +1046,9 @@ function open_data_schema_map_endpoint_process_map($ids, $api) {
       $count++;
       $index++;
       if ($count == 100 || $index == $total) {
-        drush_log("Processed $index out of $total items", "ok");
+        if (function_exists(drush_log)) {
+          drush_log("Processed $index out of $total items", "ok");
+        }
         $count = 0;
       }
     }


### PR DESCRIPTION
When clicking on links to get data in JSON or RDF, we get 503 errors, in the logs we are getting:

```
Error: Call to undefined function drush_log() in open_data_schema_map_endpoint_process_map() (line 1049 of dkan/modules/contrib/open_data_schema_map/open_data_schema_map.module).
```

So, here we are checking if function drush_log exists before using it, that way the messages will be print if needed and the site won't crash.