### PR TITLE
Do not include unpublished osdm entity reference nodes.

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -999,7 +999,15 @@ function open_data_schema_map_endpoint_process_map_recursion(&$result, $map, $ty
         }
         unset($token['odsm_entity_reference']);
         if ($values) {
+          $ref_field_info = field_info_field($ref_field);
+          $target_type = $ref_field_info['settings']['target_type'];
           foreach ($values as $num => $item) {
+            if ($target_type === 'node') {
+              $target_node = entity_load_single('node', $item['target_id']);
+              if ($target_node->status === "0") {
+                continue;
+              }
+            }
             $sub_result = array();
             foreach ($token as $subfield => $subtoken) {
               $subtoken['value'] = str_replace('Nth', $num, $subtoken['value']) ? str_replace('Nth', $num, $subtoken['value']) : $subtoken['value'];


### PR DESCRIPTION
## Description
Currently unpublished nodes are skipped, but if published nodes reference unpublished ones (e.g. a published dataset contains an unpublished resource), they are included. This modification ensures that only published referenced nodes are included.

## QA Steps (for DKAN)
1. Create a published dataset with both published and unpublished resources.
2. Run `odsm-filecache` (e.g. `drush odsm-filecache usda_ars_endpoint`).
3. Check the resulting output and confirm that the dataset includes only the published resources.