### PR TITLE
Paginate endpoints

### DIFF
--- a/open_data_schema_map.admin.inc
+++ b/open_data_schema_map.admin.inc
@@ -15,6 +15,14 @@
  */
 function open_data_schema_map_admin_settings_form($form_state) {
   $available_filters = _open_data_schema_map_get_available_filters('name');
+  $form['datasets_per_page'] = array(
+    '#type' => 'textfield',
+    '#size' => 5,
+    '#maxlength' => 5,
+    '#default_value' => variable_get('datasets_per_page', ''),
+    '#title' => t('Amount of datasets per page'),
+    '#description' => t('This will be used as the amount of datasets printed per page in catalog.xml. If not set, all the datasets will be shown in the page.'),
+  );
   $form['data_json'] = array(
     '#type' => 'fieldset',
     '#title' => t('Data Federation Filters'),
@@ -46,4 +54,26 @@ function open_data_schema_map_admin_settings_form($form_state) {
   );
 
   return system_settings_form($form);
+}
+
+/**
+ * Validate function.
+ */
+function open_data_schema_map_admin_settings_form_validate($form, &$form_state) {
+  $max_num = $form_state['values']['datasets_per_page'];
+
+  if (empty($max_num)) {
+    if ($max_num == "0") {
+      form_set_error('datasets_per_page', t('Amount of datasets per page cannot be 0.'));
+    }
+  } else {
+    if (!is_numeric($max_num)) {
+      form_set_error('datasets_per_page', t('You must enter a number for the amount of datasets per page.'));
+    }
+    else {
+      if ($max_num < 0) {
+        form_set_error('datasets_per_page', t('Amount of datasets per page must be positive.'));
+      }
+    }
+  }
 }

--- a/open_data_schema_map.admin.inc
+++ b/open_data_schema_map.admin.inc
@@ -15,14 +15,6 @@
  */
 function open_data_schema_map_admin_settings_form($form_state) {
   $available_filters = _open_data_schema_map_get_available_filters('name');
-  $form['datasets_per_page'] = array(
-    '#type' => 'textfield',
-    '#size' => 5,
-    '#maxlength' => 5,
-    '#default_value' => variable_get('datasets_per_page', ''),
-    '#title' => t('Amount of datasets per page'),
-    '#description' => t('This will be used as the amount of datasets printed per page in catalog.xml. If not set, all the datasets will be shown in the page.'),
-  );
   $form['data_json'] = array(
     '#type' => 'fieldset',
     '#title' => t('Data Federation Filters'),
@@ -54,26 +46,4 @@ function open_data_schema_map_admin_settings_form($form_state) {
   );
 
   return system_settings_form($form);
-}
-
-/**
- * Validate function.
- */
-function open_data_schema_map_admin_settings_form_validate($form, &$form_state) {
-  $max_num = $form_state['values']['datasets_per_page'];
-
-  if (empty($max_num)) {
-    if ($max_num == "0") {
-      form_set_error('datasets_per_page', t('Amount of datasets per page cannot be 0.'));
-    }
-  } else {
-    if (!is_numeric($max_num)) {
-      form_set_error('datasets_per_page', t('You must enter a number for the amount of datasets per page.'));
-    }
-    else {
-      if ($max_num < 0) {
-        form_set_error('datasets_per_page', t('Amount of datasets per page must be positive.'));
-      }
-    }
-  }
 }

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1182,6 +1182,7 @@ function open_data_schema_map_open_data_schema_map_args_alter(&$field, &$arg) {
  *   Array of results/headers
  */
 function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
+  $current_page = 0;
   if (!isset($queries)) {
     $queries = drupal_get_query_parameters();
   }
@@ -1208,6 +1209,24 @@ function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
       $offset = open_data_schema_map_endpoint_special_arg($args, 'offset');
       $limit = open_data_schema_map_endpoint_special_arg($args, 'limit');
       $ids = open_data_schema_map_endpoint_query($api, $limit, $offset, $args);
+      $total = count($ids);
+      // Handle paging.
+      if (isset($queries['page'])) {
+        $current_page = $queries['page'];
+      }
+      $datasets_limit = variable_get('datasets_per_page', '');
+      if (!empty($datasets_limit)) {
+        if ($total > $datasets_limit) {
+          $pages = floor($total / $datasets_limit);
+          if ($current_page > $pages) {
+            drupal_goto($api->endpoint, ['query' => ['page' => $pages]]);
+          }
+          else {
+            $datasets_offset = $current_page * $datasets_limit;
+            $ids = array_slice($ids, $datasets_offset, $datasets_limit);
+          }
+        }
+      }
       $result = open_data_schema_map_endpoint_process_map($ids, $api);
     }
   }

--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -73,6 +73,31 @@ class OpenDataSchemaMapException extends Exception {
 function open_data_schema_map_menu() {
   $items = array();
   $pre = OPEN_DATA_SCHEMA_MAP_ADMIN_PATH;
+  $config_parent_normal_path = 'admin/dkan';
+  $config_plid = db_query("SELECT mlid FROM {menu_links} WHERE link_path = :parent AND menu_name = :menu", array(':parent' => $config_parent_normal_path, ':menu' => 'menu-command-center-menu'))->fetchField();
+
+
+  $items['admin/dkan/datasets_per_page'] = array(
+    'title' => t('Datasets per page'),
+    'description' => t('Configure datasets per page for catalog.xml endpoints'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('open_data_schema_map_datasets_per_page_form'),
+    'access arguments' => array('administer DKAN configuration'),
+    'type' => MENU_NORMAL_ITEM,
+  );
+
+  $items['cc/admin/dkan/datasets_per_page'] = array(
+    'access arguments' => array('administer DKAN configuration'),
+    'description' => t('Configure datasets per page for catalog.xml endpoints'),
+    'page callback' => 'drupal_goto',
+    'page arguments' => array('admin/dkan/datasets_per_page'),
+    'title' => t('Datasets per page'),
+    'menu_name' => 'menu-command-center-menu',
+    'parent_identifier' => 'menu-command-center-menu_site-configuration:admin/dkan',
+    'plid' => $config_plid,
+    'type' => MENU_NORMAL_ITEM,
+    'weight' => 11,
+  );
 
   $apis = open_data_schema_map_api_load_all();
   if ($apis) {
@@ -161,6 +186,48 @@ function open_data_schema_map_menu() {
   }
 
   return $items;
+}
+
+/**
+ * Datasets per page form.
+ *
+ * @param array $form_state
+ *   Form state array
+ *
+ * @return array
+ *   Form array
+ */
+function open_data_schema_map_datasets_per_page_form() {
+  $form['datasets_per_page'] = array(
+    '#type' => 'textfield',
+    '#size' => 5,
+    '#maxlength' => 5,
+    '#default_value' => variable_get('datasets_per_page', ''),
+    '#title' => t('Amount of datasets per page'),
+    '#description' => t('If your catalog contains thousands of datasets, your API endpoints may get too large to load. To reduce the strain on your server, we recommend that you add pagination to the catalog.xml endpoints. To enable pagination, simply specify the number of results per page you would like in the field above and click save. If nothing is entered, all datasets will be included on a single page.'),
+  );
+  return system_settings_form($form);
+}
+
+/**
+ * Validate function.
+ */
+function open_data_schema_map_datasets_per_page_form_validate($form, &$form_state) {
+  $max_num = $form_state['values']['datasets_per_page'];
+
+  if (empty($max_num)) {
+    if ($max_num == "0") {
+      form_set_error('datasets_per_page', t('Amount of datasets per page cannot be 0.'));
+    }
+  } else {
+    if (!is_numeric($max_num)) {
+      form_set_error('datasets_per_page', t('You must enter a number for the amount of datasets per page.'));
+    } else {
+      if ($max_num < 0) {
+        form_set_error('datasets_per_page', t('Amount of datasets per page must be positive.'));
+      }
+    }
+  }
 }
 
 /**

--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -492,6 +492,10 @@ function open_data_schema_map_add_type(&$values, $mapping) {
  *   API object
  */
 function open_data_schema_map_endpoint($api) {
+  $params = drupal_get_query_parameters();
+  if (!isset($params['page'])) {
+    drupal_goto($api->endpoint, ['query' => ['page' => 0]]);
+  }
   // Start by setting the content type header based on the API settings.
   if ($output_format = open_data_schema_map_output_format_load($api->outputformat)) {
     foreach ($output_format['headers'] as $key => $value) {


### PR DESCRIPTION
## Test steps:
1. Go to `admin/config/services/odsm/settings`
  - [ ] there should be a new field for `Amount of datasets per page`
  - [ ] values on the field should be numeric
  - [ ] values on the field should be positivo
  - [ ] zero should not be allowed in the field
  - [ ] save a positive number and confirm when the page reloads it is still there
2. Go to the endpoint `catalog.xml`:
  - [ ] confirm `?page=0` is added to the url
  - [ ] if you left the `Amount of datasets per page` empty in odsm/settings from step 1, then the page shouldn't load correctly
  - [ ] if you added a small value (like 10) in the field `Amount of datasets per page` in odsm/settings from step 1, then the page should load correctly 
  - [ ] add in the url an absurd value for the page, for example `catalog.xml?page=4000`, you should get redirected to the last posible page (you can test changing the `Amount of datasets per page` to confirm the amount of pages is different depending on how many datasets are in the page).

## Notes: 
- On sites with a lot of data, I recommend to set the "Amount of datasets per page" to be a small value so the page doesn't take so much time to load.
- If "Amount of datasets per page" is not set, then the endpoint will have just one page with all the data.
- Multiple endpoints were affected by this, you can check the full list of available endpoints in `admin/config/services/odsm`, in all the cases the query param is added to the url.
- The pagination is affecting the following endpoints:
  - /api/3/action/current_package_list_with_resources 
  - /api/3/action/group_list
  - /catalog.xml
  - /catalog.json