### PR TITLE
Fixed issue on generation of data.json

### DIFF
--- a/open_data_schema_map.module
+++ b/open_data_schema_map.module
@@ -1290,7 +1290,7 @@ function open_data_schema_map_render_api($api, $query = NULL, $queries = NULL) {
         $current_page = $queries['page'];
       }
       $datasets_limit = variable_get('datasets_per_page', '');
-      if (!empty($datasets_limit)) {
+      if (!empty($datasets_limit && isset($queries['page']))) {
         if ($total > $datasets_limit) {
           $pages = floor($total / $datasets_limit);
           if ($current_page > $pages) {


### PR DESCRIPTION
## Steps to test:
- [x] Go to /catalog.xml confirm it is still paginating results when `Datasets per page` is not empty.
- [x] Go to data.json and confirm it shows all the data.
- [x] Run `drush odsm-filecache data_json_1_1`, confirm that even when `Datasets per page` is not empty, all the datasets are processed.
- [x] Go to data.json again and confirm all the data is still there.