### PR TITLE
Fix broken RDF and JSON links

### DIFF
--- a/open_data_schema_map.pages.inc
+++ b/open_data_schema_map.pages.inc
@@ -494,7 +494,8 @@ function open_data_schema_map_add_type(&$values, $mapping) {
 function open_data_schema_map_endpoint($api) {
   $params = drupal_get_query_parameters();
   if (!isset($params['page'])) {
-    drupal_goto($api->endpoint, ['query' => ['page' => 0]]);
+    $params['page'] = 0;
+    drupal_goto($api->endpoint, ['query' => $params]);
   }
   // Start by setting the content type header based on the API settings.
   if ($output_format = open_data_schema_map_output_format_load($api->outputformat)) {


### PR DESCRIPTION
RDF and JSON links are broken because the id param isn't present anymore.

When adding the pagination for the endpoints, a page=0 param was added by default to all of them, but it was overriding them all, this PR makes it so it is appended and keep the other parameters.

## How to reproduce
- Go to a dataset page
- Click on the RDF or JSON links under "Other access"
- You get a Validation error.

## Steps to test
- [ ] Go to a dataset page
- [ ] Click on the RDF or JSON links under "Other access"
- [ ] Both links should work, they should contain a query param for id and another for page.